### PR TITLE
Update README to reflect renamed --tapes-dir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn global add proxay
 proxay --mode record --host https://api.website.com --tapes tapes/
 
 # Replay mode (no proxying)
-proxay --mode replay --tapes tapes/
+proxay --mode replay --tapes-dir tapes/
 
 # Passthrough mode (proxies requests without persisting)
 proxay --mode passthrough --host https://api.website.com


### PR DESCRIPTION
This was changed in https://github.com/airtasker/proxay/commit/1aa32f9aec350f76c13f5037b65d04da6852d1b1#diff-cd02b9e0b731a6a1dedefed142f4419bR12, which was released in 1.2.17.

This should fix #151 :)