### PR TITLE
Fix `--tapes` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn global add proxay
 
 ```sh
 # Record mode (proxies requests)
-proxay --mode record --host https://api.website.com --tapes tapes/
+proxay --mode record --host https://api.website.com --tapes-dir tapes/
 
 # Replay mode (no proxying)
 proxay --mode replay --tapes-dir tapes/


### PR DESCRIPTION
Related to https://github.com/airtasker/proxay/issues/151

I came across this same issue, on a different usage example, it looks like this usage was overlooked.