### PR TITLE
ARCH-469 Redact specified headers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import program from "commander";
 import fs from "fs-extra";
 import { RecordReplayServer } from "./server";
 
-function commaSeparatedList(value: string, dummyPrevious: any) {
+function commaSeparatedList(value: string, _dummyPrevious?: any) {
   return value ? value.split(',') : [];
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import fs from "fs-extra";
 import { RecordReplayServer } from "./server";
 
 function commaSeparatedList(value: string, _dummyPrevious?: any) {
-  return value ? value.split(',') : [];
+  return value ? value.split(",") : [];
 }
 
 async function main(argv: string[]) {
@@ -19,7 +19,11 @@ async function main(argv: string[]) {
     .option("--default-tape <tape-name>", "Name of the default tape", "default")
     .option("-h, --host <host>", "Host to proxy (not required in replay mode)")
     .option("-p, --port <port>", "Local port to serve on", "3000")
-    .option("-r, --redact-headers <headers>", "Request headers to redact", commaSeparatedList)
+    .option(
+      "-r, --redact-headers <headers>",
+      "Request headers to redact",
+      commaSeparatedList
+    )
     .parse(argv);
 
   const initialMode: string = (program.mode || "").toLowerCase();
@@ -27,7 +31,7 @@ async function main(argv: string[]) {
   const defaultTapeName: string = program.defaultTape;
   const host: string = program.host;
   const port = parseInt(program.port, 10);
-  const redactHeaders: string[] = program.redactHeaders
+  const redactHeaders: string[] = program.redactHeaders;
 
   switch (initialMode) {
     case "record":
@@ -67,7 +71,7 @@ async function main(argv: string[]) {
     host,
     defaultTapeName,
     enableLogging: true,
-    redactHeaders
+    redactHeaders,
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,10 @@ import program from "commander";
 import fs from "fs-extra";
 import { RecordReplayServer } from "./server";
 
+function commaSeparatedList(value: string, dummyPrevious: any) {
+  return value ? value.split(',') : [];
+}
+
 async function main(argv: string[]) {
   program
     .option("-m, --mode <mode>", "Mode (record, replay or passthrough)")
@@ -15,6 +19,7 @@ async function main(argv: string[]) {
     .option("--default-tape <tape-name>", "Name of the default tape", "default")
     .option("-h, --host <host>", "Host to proxy (not required in replay mode)")
     .option("-p, --port <port>", "Local port to serve on", "3000")
+    .option("-r, --redact-headers <headers>", "Request headers to redact", commaSeparatedList)
     .parse(argv);
 
   const initialMode: string = (program.mode || "").toLowerCase();
@@ -22,6 +27,7 @@ async function main(argv: string[]) {
   const defaultTapeName: string = program.defaultTape;
   const host: string = program.host;
   const port = parseInt(program.port, 10);
+  const redactHeaders = program.redactHeaders
 
   switch (initialMode) {
     case "record":
@@ -61,6 +67,7 @@ async function main(argv: string[]) {
     host,
     defaultTapeName,
     enableLogging: true,
+    redactHeaders: redactHeaders
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import program from "commander";
 import fs from "fs-extra";
 import { RecordReplayServer } from "./server";
 
-function commaSeparatedList(value: string, _dummyPrevious?: any) {
+function commaSeparatedList(value: string) {
   return value ? value.split(",") : [];
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ async function main(argv: string[]) {
   const defaultTapeName: string = program.defaultTape;
   const host: string = program.host;
   const port = parseInt(program.port, 10);
-  const redactHeaders = program.redactHeaders
+  const redactHeaders: string[] = program.redactHeaders
 
   switch (initialMode) {
     case "record":
@@ -67,7 +67,7 @@ async function main(argv: string[]) {
     host,
     defaultTapeName,
     enableLogging: true,
-    redactHeaders: redactHeaders
+    redactHeaders
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));

--- a/src/persistence.spec.ts
+++ b/src/persistence.spec.ts
@@ -98,7 +98,7 @@ describe("Redaction", () => {
       }
     redactRequestHeaders(record, ['x-auth-token'])
     expect(record.request.headers['x-auth-token']).not.toEqual(sensitiveData)
-    expect(record.request.headers['host']).toEqual(hostname)
+    expect(record.request.headers.host).toEqual(hostname)
   })
 });
 

--- a/src/persistence.spec.ts
+++ b/src/persistence.spec.ts
@@ -97,7 +97,7 @@ describe("Redaction", () => {
       },
     };
     redactRequestHeaders(record, ["x-auth-token"]);
-    expect(record.request.headers["x-auth-token"]).not.toEqual(sensitiveData);
+    expect(record.request.headers["x-auth-token"]).toEqual("XXXX");
     expect(record.request.headers.host).toEqual(hostname);
   });
 });

--- a/src/persistence.spec.ts
+++ b/src/persistence.spec.ts
@@ -79,27 +79,27 @@ const BINARY_RESPONSE_GZIP = gzipSync(BINARY_RESPONSE);
 
 describe("Redaction", () => {
   it("redacts specified headers", () => {
-    const sensitiveData = 'some sensitive data';
-    const hostname = 'some-host'
+    const sensitiveData = "some sensitive data";
+    const hostname = "some-host";
     const record = {
-        request: {
-          method: "GET",
-          path: "/path",
-          headers: {host: hostname, 'x-auth-token': sensitiveData},
-          body: Buffer.from(UTF8_REQUEST, "utf8"),
+      request: {
+        method: "GET",
+        path: "/path",
+        headers: { host: hostname, "x-auth-token": sensitiveData },
+        body: Buffer.from(UTF8_REQUEST, "utf8"),
+      },
+      response: {
+        status: {
+          code: 200,
         },
-        response: {
-          status: {
-            code: 200,
-          },
-          headers: {},
-          body: Buffer.from(UTF8_RESPONSE, "utf8"),
-        },
-      }
-    redactRequestHeaders(record, ['x-auth-token'])
-    expect(record.request.headers['x-auth-token']).not.toEqual(sensitiveData)
-    expect(record.request.headers.host).toEqual(hostname)
-  })
+        headers: {},
+        body: Buffer.from(UTF8_RESPONSE, "utf8"),
+      },
+    };
+    redactRequestHeaders(record, ["x-auth-token"]);
+    expect(record.request.headers["x-auth-token"]).not.toEqual(sensitiveData);
+    expect(record.request.headers.host).toEqual(hostname);
+  });
 });
 
 describe("Persistence", () => {

--- a/src/persistence.spec.ts
+++ b/src/persistence.spec.ts
@@ -1,6 +1,6 @@
 import brotli from "brotli";
 import { gzipSync } from "zlib";
-import { persistTape, reviveTape } from "./persistence";
+import { persistTape, reviveTape, redactRequestHeaders } from "./persistence";
 
 // Note the repetition. This is necessary otherwise Brotli compression
 // will be null.
@@ -76,6 +76,31 @@ const UTF8_REQUEST_GZIP = gzipSync(Buffer.from(UTF8_REQUEST, "utf8"));
 const UTF8_RESPONSE_GZIP = gzipSync(Buffer.from(UTF8_RESPONSE, "utf8"));
 const BINARY_REQUEST_GZIP = gzipSync(BINARY_REQUEST);
 const BINARY_RESPONSE_GZIP = gzipSync(BINARY_RESPONSE);
+
+describe("Redaction", () => {
+  it("redacts specified headers", () => {
+    const sensitiveData = 'some sensitive data';
+    const hostname = 'some-host'
+    const record = {
+        request: {
+          method: "GET",
+          path: "/path",
+          headers: {host: hostname, 'x-auth-token': sensitiveData},
+          body: Buffer.from(UTF8_REQUEST, "utf8"),
+        },
+        response: {
+          status: {
+            code: 200,
+          },
+          headers: {},
+          body: Buffer.from(UTF8_RESPONSE, "utf8"),
+        },
+      }
+    redactRequestHeaders(record, ['x-auth-token'])
+    expect(record.request.headers['x-auth-token']).not.toEqual(sensitiveData)
+    expect(record.request.headers['host']).toEqual(hostname)
+  })
+});
 
 describe("Persistence", () => {
   it("persists utf-8", () => {

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -15,7 +15,7 @@ import {
  * Persistence layer to save tapes to disk and read them from disk.
  */
 export class Persistence {
-  constructor(private tapeDir: string, private redactHeaders: string[]) {}
+  constructor(private readonly tapeDir: string, private readonly redactHeaders: string[]) {}
 
   /**
    * Saves the tape to disk.

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -21,7 +21,9 @@ export class Persistence {
    * Saves the tape to disk.
    */
   saveTapeToDisk(tapeName: string, tapeRecords: TapeRecord[]) {
-    const persistedTapeRecords = tapeRecords.map(this.redact, this).map(persistTape);
+    const persistedTapeRecords = tapeRecords
+      .map(this.redact, this)
+      .map(persistTape);
     const tapePath = this.getTapePath(tapeName);
     fs.ensureDirSync(path.dirname(tapePath));
     fs.writeFileSync(
@@ -72,10 +74,13 @@ export class Persistence {
 /**
  * Redacts the headers of the given record based on the provided array of headers to redact
  */
-export function redactRequestHeaders(record: TapeRecord, redactHeaders: string[]) {
-  redactHeaders.forEach(header => {
+export function redactRequestHeaders(
+  record: TapeRecord,
+  redactHeaders: string[]
+) {
+  redactHeaders.forEach((header) => {
     if (record.request.headers[header]) {
-      record.request.headers[header] = 'XXXX';
+      record.request.headers[header] = "XXXX";
     }
   });
 }

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -15,7 +15,10 @@ import {
  * Persistence layer to save tapes to disk and read them from disk.
  */
 export class Persistence {
-  constructor(private readonly tapeDir: string, private readonly redactHeaders: string[]) {}
+  constructor(
+    private readonly tapeDir: string,
+    private readonly redactHeaders: string[]
+  ) {}
 
   /**
    * Saves the tape to disk.

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -15,13 +15,13 @@ import {
  * Persistence layer to save tapes to disk and read them from disk.
  */
 export class Persistence {
-  constructor(private tapeDir: string) {}
+  constructor(private tapeDir: string, private redactHeaders: string[]) {}
 
   /**
    * Saves the tape to disk.
    */
   saveTapeToDisk(tapeName: string, tapeRecords: TapeRecord[]) {
-    const persistedTapeRecords = tapeRecords.map(persistTape);
+    const persistedTapeRecords = tapeRecords.map(this.redact, this).map(persistTape);
     const tapePath = this.getTapePath(tapeName);
     fs.ensureDirSync(path.dirname(tapePath));
     fs.writeFileSync(
@@ -31,6 +31,14 @@ export class Persistence {
       }),
       "utf8"
     );
+  }
+
+  /**
+   * Redacts the request headers of the given record, depending on the redactHeaders array
+   */
+  private redact(record: TapeRecord): TapeRecord {
+    redactRequestHeaders(record, this.redactHeaders);
+    return record;
   }
 
   /**
@@ -59,6 +67,17 @@ export class Persistence {
   private getTapePath(tapeName: string) {
     return path.join(this.tapeDir, `${tapeName}.yml`);
   }
+}
+
+/**
+ * Redacts the headers of the given record based on the provided array of headers to redact
+ */
+export function redactRequestHeaders(record: TapeRecord, redactHeaders: string[]) {
+  redactHeaders.forEach(header => {
+    if (record.request.headers[header]) {
+      record.request.headers[header] = 'XXXX';
+    }
+  });
 }
 
 export function persistTape(record: TapeRecord): PersistedTapeRecord {

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,13 +31,15 @@ export class RecordReplayServer {
     host?: string;
     timeout?: number;
     enableLogging?: boolean;
+    redactHeaders?: string[];
   }) {
     this.currentTapeRecords = [];
     this.mode = options.initialMode;
     this.proxiedHost = options.host;
     this.timeout = options.timeout || 5000;
     this.loggingEnabled = options.enableLogging || false;
-    this.persistence = new Persistence(options.tapeDir);
+    const redactHeaders = options.redactHeaders || [];
+    this.persistence = new Persistence(options.tapeDir, redactHeaders);
     this.defaultTape = options.defaultTapeName;
     this.loadTape(this.defaultTape);
 


### PR DESCRIPTION
## Description & Context
Introduces an option to proxay which will allow sensitive data in request headers to be redacted in the associated tapes. As we generally commit proxay tapes to source control this allows us to keep sensitive header values, such as access control keys and auth tokens, out of the tapes.
