### PR TITLE
[AUTH-1236] Prevent conditional requests from being made during tape recording, so that conditional responses are not returned during replay

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,9 +25,8 @@ async function main(argv: string[]) {
       commaSeparatedList
     )
     .option(
-      "--prevent-conditional-requests <flag>",
-      "When running in record mode, remove `If-*` headers from outgoing requests in an attempt to prevent the suite of conditional responses being returned (304).",
-      "true"
+      "--no-drop-conditional-request-headers",
+      "When running in record mode, by default, `If-*` headers from outgoing requests are dropped in an attempt to prevent the suite of conditional responses being returned (e.g. 304). Supplying this flag disables this default behaviour"
     )
     .parse(argv);
 
@@ -37,8 +36,7 @@ async function main(argv: string[]) {
   const host: string = program.host;
   const port = parseInt(program.port, 10);
   const redactHeaders: string[] = program.redactHeaders;
-  const preventConditionalRequests: boolean =
-    program.preventConditionalRequests === "true";
+  const preventConditionalRequests: boolean = !!program.dropConditionalRequestHeaders;
 
   switch (initialMode) {
     case "record":
@@ -62,7 +60,7 @@ async function main(argv: string[]) {
     );
   }
 
-  if (initialMode === "record" && preventConditionalRequests) {
+  if (preventConditionalRequests && initialMode === "record") {
     console.info(
       "The prevent conditional requests flag is enabled in record mode. All received `If-*` headers will not be forwarded on upstream and will not be recorded in tapes."
     );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ async function main(argv: string[]) {
     .option(
       "--prevent-conditional-requests <flag>",
       "When running in record mode, remove `If-*` headers from outgoing requests in an attempt to prevent the suite of conditional responses being returned (304).",
-      "false"
+      "true"
     )
     .parse(argv);
 
@@ -59,6 +59,12 @@ async function main(argv: string[]) {
   if (initialMode === "replay" && !fs.existsSync(tapeDir)) {
     panic(
       `No tapes found at ${tapeDir}. Did you mean to start in record mode?`
+    );
+  }
+
+  if (initialMode === "record" && preventConditionalRequests) {
+    console.info(
+      "The prevent conditional requests flag is enabled in record mode. All received `If-*` headers will not be forwarded on upstream and will not be recorded in tapes."
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,11 @@ async function main(argv: string[]) {
       "Request headers to redact",
       commaSeparatedList
     )
+    .option(
+      "--prevent-conditional-requests <flag>",
+      "When running in record mode, remove `If-*` headers from outgoing requests in an attempt to prevent the suite of conditional responses being returned (304).",
+      "false"
+    )
     .parse(argv);
 
   const initialMode: string = (program.mode || "").toLowerCase();
@@ -32,6 +37,8 @@ async function main(argv: string[]) {
   const host: string = program.host;
   const port = parseInt(program.port, 10);
   const redactHeaders: string[] = program.redactHeaders;
+  const preventConditionalRequests: boolean =
+    program.preventConditionalRequests === "true";
 
   switch (initialMode) {
     case "record":
@@ -72,6 +79,7 @@ async function main(argv: string[]) {
     defaultTapeName,
     enableLogging: true,
     redactHeaders,
+    preventConditionalRequests,
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,7 +67,6 @@ export class RecordReplayServer {
         // Headers are always coming in as lowercase.
         delete req.headers["if-modified-since"];
         delete req.headers["if-none-match"];
-        console.log(`Attempted to delete headers. ${req.method} ${JSON.stringify(req.headers)}`);
       }
 
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,8 +64,9 @@ export class RecordReplayServer {
         this.preventConditionalRequests &&
         (req.method === "GET" || req.method === "HEAD")
       ) {
-        delete req.headers["If-Modified-Since"];
-        delete req.headers["If-None-Match"];
+        // Headers are always coming in as lowercase.
+        delete req.headers["if-modified-since"];
+        delete req.headers["if-none-match"];
         console.log(`Attempted to delete headers. ${req.method} ${JSON.stringify(req.headers)}`);
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,7 @@ export class RecordReplayServer {
       ) {
         delete req.headers["If-Modified-Since"];
         delete req.headers["If-None-Match"];
+        console.log(`Attempted to delete headers. ${req.method} ${JSON.stringify(req.headers)}`);
       }
 
       try {


### PR DESCRIPTION
Prevent conditional requests from being made during tape recording, so that conditional responses are not returned during replay.