### PR TITLE
PSC-265 fail gracefully when no tape is found #technical

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -279,6 +279,8 @@ export class RecordReplayServer {
           )
         );
       }
+      // If no tape is found attempt to make the original request
+      return this.fetchPassthroughResponse(request)
     }
     return record;
   }

--- a/src/tests/replay.spec.ts
+++ b/src/tests/replay.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "./testserver";
 
 describe("Replay", () => {
-  setupServers({ mode: "replay" });
+  const servers = setupServers({ mode: "replay" });
 
   test("response: simple text", async () => {
     const response = await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
@@ -36,11 +36,17 @@ describe("Replay", () => {
     });
   });
 
-  test("cannot pick a tape that does not exist", async () => {
-    await expect(
-      axios.post(`${PROXAY_HOST}/__proxay/tape`, {
-        tape: "does-not-exist-tape",
-      })
-    ).rejects.toEqual(new Error("Request failed with status code 404"));
+  test("makes the original request if no tape is found", async () => {
+    const requestCount = servers.backend.requestCount;
+
+    // Neither calls will be recorded.
+    expect((await axios.get(`${PROXAY_HOST}/only-records`)).data).toBe(
+        "/only-records"
+    );
+    expect((await axios.get(`${PROXAY_HOST}/only-records`)).data).toBe(
+        "/only-records"
+    );
+    expect(servers.backend.requestCount).toBe(requestCount + 2); // Unchanged.
   });
+
 });


### PR DESCRIPTION
## Why 
As part of the auth0 web rollout we are now hitting the auth service when creating users. As this is a different host these requests are not recorded as tapes. This results in test failures as a new user is created each time the test is run but the tapes were recorded for a different user (the user created when the tapes were first recorded).

The problem with the auth0 flow is that we are now using cookie based authentication. This means the cookie/set-cookie headers in the tapes are interfering with the new users being created on each run.

This is a short term alternative to setting up multiple hosts, this should allow us to edit the tapes for requests which should not be recorded/replayed.

As a side effect this means that our tests will not fail if there is a tape missing, which could lead us to forgot to add them. Open to thoughts on how we feel about this. We would know if tapes are missing as the average time to run the tests would increase over time.


## What 
- make the original request when a tape is missing
- Configured with env var 