### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0
+
+* Allow optional rewrite rules before computing similarity scores during replay (#499).
+
 # 1.4.0
 
 * Optionally support accepting incoming requests on HTTPS in addition to HTTP (#472).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxay",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "François Wouts",
     "email": "f@zenc.io"


### PR DESCRIPTION
Following #474 and https://github.com/airtasker/proxay/tree/master#releasing-a-new-version-of-proxay-for-contributors, this PR creates a new release for the new functionality.