### PR TITLE
[TEX-537] Allow wildcard hostname for unframing `gRPC-web+json` requests

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,7 @@ async function main(argv: string[]) {
     )
     .option(
       "--unframe-grpc-web-json-requests-hostname [hostname...]",
-      "Rewrite received requests whose content-type is application/grpc-web+json to be application/json, mutating the body of the request accordingly. This is useful if you want plain text tape records rather than binary data. The gRPC server needs to support receiving unframed requests for this option to be useful."
+      "Rewrite received requests whose content-type is application/grpc-web+json to be application/json, mutating the body of the request accordingly. This is useful if you want plain text tape records rather than binary data. The gRPC server needs to support receiving unframed requests for this option to be useful. To accept all host headers, use `*`, otherwise specifiy one or more host header values to whitelist."
     )
     .option<RewriteRules>(
       "--rewrite-before-diff [s/find/replace/g...]",

--- a/src/server.ts
+++ b/src/server.ts
@@ -263,9 +263,9 @@ export class RecordReplayServer {
     if (
       request.method === "POST" &&
       request.headers["content-type"] === "application/grpc-web+json" &&
-      hostname != null &&
-      (this.unframeGrpcWebJsonRequestsHostnames.includes(hostname) ||
-        this.unframeGrpcWebJsonRequestsHostnames.includes("*"))
+      (this.unframeGrpcWebJsonRequestsHostnames.includes("*") ||
+        (hostname != null &&
+          this.unframeGrpcWebJsonRequestsHostnames.includes(hostname)))
     ) {
       this.rewriteGrpcWebJsonRequest(request);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -264,7 +264,8 @@ export class RecordReplayServer {
       request.method === "POST" &&
       request.headers["content-type"] === "application/grpc-web+json" &&
       hostname != null &&
-      this.unframeGrpcWebJsonRequestsHostnames.includes(hostname)
+      (this.unframeGrpcWebJsonRequestsHostnames.includes(hostname) ||
+        this.unframeGrpcWebJsonRequestsHostnames.includes("*"))
     ) {
       this.rewriteGrpcWebJsonRequest(request);
     }

--- a/src/tests/passthrough.spec.ts
+++ b/src/tests/passthrough.spec.ts
@@ -38,8 +38,96 @@ describe("Passthrough", () => {
   });
 });
 
-describe("Passthrough with grpc-web+json unframing", () => {
-  setupServers({ mode: "passthrough", enableUnframeGrpcWebJson: true });
+describe("Passthrough with grpc-web+json unframing with explicit whitelisted hostname", () => {
+  setupServers({
+    mode: "passthrough",
+    unframeGrpcWebJsonRequestsHostnames: [`localhost:${TEST_SERVER_PORT}`],
+  });
+
+  test("response: simple text", async () => {
+    const response = await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
+    expect(response.data).toBe(SIMPLE_TEXT_RESPONSE);
+  });
+
+  test("response: utf-8", async () => {
+    const response = await axios.get(`${PROXAY_HOST}${UTF8_PATH}`);
+    expect(response.data).toBe(UTF8_RESPONSE);
+  });
+
+  test("response: binary", async () => {
+    const response = await axios.get(`${PROXAY_HOST}${BINARY_PATH}`, {
+      responseType: "arraybuffer",
+    });
+    expect(response.data).toEqual(BINARY_RESPONSE);
+  });
+
+  test("can pick any tape", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "new-tape",
+    });
+  });
+
+  test("unframes a grpc-web+json request", async () => {
+    const requestBody = Buffer.from([
+      0,
+      0,
+      0,
+      0,
+      31,
+      123,
+      34,
+      101,
+      109,
+      97,
+      105,
+      108,
+      34,
+      58,
+      34,
+      102,
+      111,
+      111,
+      46,
+      98,
+      97,
+      114,
+      64,
+      101,
+      120,
+      97,
+      109,
+      112,
+      108,
+      101,
+      46,
+      99,
+      111,
+      109,
+      34,
+      125,
+    ]);
+    const response = await axios.post(
+      `${PROXAY_HOST}${GRPC_WEB_JSON_PATH}`,
+      requestBody,
+      {
+        headers: {
+          "content-type": "application/grpc-web+json",
+          host: `localhost:${TEST_SERVER_PORT}`,
+        },
+      }
+    );
+    expect(response.headers["content-type"]).toBe(
+      "application/json; charset=utf-8"
+    );
+    expect(response.data).toEqual({ email: "foo.bar@example.com" });
+  });
+});
+
+describe("Passthrough with grpc-web+json unframing with wildcard whitelisted hostname", () => {
+  setupServers({
+    mode: "passthrough",
+    unframeGrpcWebJsonRequestsHostnames: ["*"],
+  });
 
   test("response: simple text", async () => {
     const response = await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -9,12 +9,12 @@ export function setupServers({
   mode,
   tapeDirName = mode,
   defaultTapeName = "default",
-  enableUnframeGrpcWebJson = false,
+  unframeGrpcWebJsonRequestsHostnames = undefined,
 }: {
   mode: Mode;
   tapeDirName?: string;
   defaultTapeName?: string;
-  enableUnframeGrpcWebJson?: boolean;
+  unframeGrpcWebJsonRequestsHostnames?: string[];
 }) {
   const tapeDir = path.join(__dirname, "tapes", tapeDirName);
   const servers = { tapeDir } as {
@@ -37,9 +37,7 @@ export function setupServers({
       defaultTapeName,
       host: TEST_SERVER_HOST,
       timeout: 100,
-      unframeGrpcWebJsonRequestsHostnames: enableUnframeGrpcWebJson
-        ? [`localhost:${TEST_SERVER_PORT}`]
-        : [],
+      unframeGrpcWebJsonRequestsHostnames: unframeGrpcWebJsonRequestsHostnames,
     });
     await Promise.all([
       servers.proxy.start(PROXAY_PORT),

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -9,7 +9,7 @@ export function setupServers({
   mode,
   tapeDirName = mode,
   defaultTapeName = "default",
-  unframeGrpcWebJsonRequestsHostnames = undefined,
+  unframeGrpcWebJsonRequestsHostnames,
 }: {
   mode: Mode;
   tapeDirName?: string;
@@ -37,7 +37,7 @@ export function setupServers({
       defaultTapeName,
       host: TEST_SERVER_HOST,
       timeout: 100,
-      unframeGrpcWebJsonRequestsHostnames: unframeGrpcWebJsonRequestsHostnames,
+      unframeGrpcWebJsonRequestsHostnames,
     });
     await Promise.all([
       servers.proxy.start(PROXAY_PORT),


### PR DESCRIPTION
This is a small extension upon the functionality added in #501. This PR extends the whitelist of hostnames to allow a `*` wildcard in order to signify that any hostname should be allowed for `grpc-web+json` unframing.