### PR TITLE
[NT] Improve CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
             JEST_JUNIT_OUTPUT_NAME: results.xml
             JEST_JUNIT_CLASSNAME: "{filepath}"
-          command: yarn ci:test
+          command: env NODE_OPTIONS=--trace-warnings yarn ci:test
       - store_test_results:
           path: ./test-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
             JEST_JUNIT_OUTPUT_NAME: results.xml
             JEST_JUNIT_CLASSNAME: "{filepath}"
-          command: env NODE_OPTIONS=--trace-warnings yarn ci:test
+          command: yarn ci:test
       - store_test_results:
           path: ./test-reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,13 @@ commands:
       - install-dependencies
       - run:
           name: Run the unit tests
-          command: yarn test
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./test-reports/jest
+            JEST_JUNIT_OUTPUT_NAME: results.xml
+            JEST_JUNIT_CLASSNAME: "{filepath}"
+          command: yarn ci:test
+      - store_test_results:
+          path: ./test-reports
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,105 @@
 version: 2.1
-job_configuration: &job_configuration
-  docker:
-    - image: circleci/node:10-stretch
-  working_directory: ~/repo
-jobs:
-  test:
-    <<: *job_configuration
+
+executors:
+  node10:
+    docker:
+      - image: cimg/node:10.24.0
+    resource_class: medium
+    working_directory: ~/repo
+
+  node12:
+    docker:
+      - image: cimg/node:12.13.1
+    resource_class: medium
+    working_directory: ~/repo
+
+  node14:
+    docker:
+      - image: cimg/node:14.21.3
+    resource_class: medium
+    working_directory: ~/repo
+
+  node16:
+    docker:
+      - image: cimg/node:16.20.1
+    resource_class: medium
+    working_directory: ~/repo
+
+  node18:
+    docker:
+      - image: cimg/node:18.18.1
+    resource_class: medium
+    working_directory: ~/repo
+
+  node20:
+    docker:
+      - image: cimg/node:20.4.0
+    resource_class: medium
+    working_directory: ~/repo
+
+
+commands:
+  install-dependencies:
+    description: Convenience command to install the dependencies, cached.
     steps:
-      - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
-      - run: yarn install
+      - run:
+          name: Install main dependencies
+          command: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-      - run: yarn test
+
+  run-tests:
+    description: A helper command to do the full set of steps to run the tests.
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Run the unit tests
+          command: yarn test
+
+
+jobs:
+  test-node10:
+    executor: node10
+    steps:
+      - run-tests
+
+  test-node12:
+    executor: node12
+    steps:
+      - run-tests
+
+  test-node14:
+    executor: node14
+    steps:
+      - run-tests
+
+  test-node16:
+    executor: node16
+    steps:
+      - run-tests
+
+  test-node18:
+    executor: node18
+    steps:
+      - run-tests
+
+  test-node20:
+    executor: node20
+    steps:
+      - run-tests
 
   build-and-run:
-    <<: *job_configuration
+    executor: node10
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-      - run: yarn test
+      - install-dependencies
       - run: yarn build
       - run: sudo npm link
       - run: |
@@ -44,68 +111,53 @@ jobs:
             sleep 5
           done
 
-  prettier-check:
-    <<: *job_configuration
+  lint-check:
+    executor: node10
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+      - install-dependencies
       - run:
-          name: Prettier
-          command: |
-            yarn prettier --list-different "**/*.ts"
-
-  tslint-check:
-    <<: *job_configuration
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-      - run:
-          name: TSLint
-          command: |
-            yarn tslint -p .
+          name: Run prettier
+          command: yarn lint:check
 
   publish:
-    <<: *job_configuration
+    executor: node10
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
-      - run: yarn install
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+      - install-dependencies
       - run: yarn build
       - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run:
           name: Publish
-          command: |
-            npm publish --access=public
+          command: npm publish --access=public
+
 
 workflows:
   build-and-test:
     jobs:
-      - test:
+      - test-node10:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node12:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node14:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node16:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node18:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - test-node20:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
@@ -113,20 +165,20 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - prettier-check:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - tslint-check:
+      - lint-check:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
-            - test
+            - test-node10
+            - test-node12
+            - test-node14
+            - test-node16
+            - test-node18
+            - test-node20
             - build-and-run
-            - prettier-check
-            - tslint-check
+            - lint-check
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,6 @@ executors:
     resource_class: medium
     working_directory: ~/repo
 
-  node20:
-    docker:
-      - image: cimg/node:20.4.0
-    resource_class: medium
-    working_directory: ~/repo
-
 
 commands:
   install-dependencies:
@@ -93,11 +87,6 @@ jobs:
 
   test-node18:
     executor: node18
-    steps:
-      - run-tests
-
-  test-node20:
-    executor: node20
     steps:
       - run-tests
 
@@ -163,10 +152,6 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - test-node20:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - build-and-run:
           filters:
             tags:
@@ -182,7 +167,6 @@ workflows:
             - test-node14
             - test-node16
             - test-node18
-            - test-node20
             - build-and-run
             - lint-check
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,31 +4,31 @@ executors:
   node10:
     docker:
       - image: cimg/node:10.24.0
-    resource_class: medium
+    resource_class: small
     working_directory: ~/repo
 
   node12:
     docker:
       - image: cimg/node:12.13.1
-    resource_class: medium
+    resource_class: small
     working_directory: ~/repo
 
   node14:
     docker:
       - image: cimg/node:14.21.3
-    resource_class: medium
+    resource_class: small
     working_directory: ~/repo
 
   node16:
     docker:
       - image: cimg/node:16.20.1
-    resource_class: medium
+    resource_class: small
     working_directory: ~/repo
 
   node18:
     docker:
       - image: cimg/node:18.18.1
-    resource_class: medium
+    resource_class: small
     working_directory: ~/repo
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "ts-node src/cli.ts",
     "start:hot": "ts-node-dev --respawn src/cli.ts",
-    "test": "jest --runInBand",
+    "test": "jest",
+    "ci:test": "jest --ci",
     "build": "rm -rf dist && tsc",
     "lint:check": "yarn prettier:check && yarn tslint:check",
     "tslint:check": "tslint -p .",
@@ -26,6 +27,7 @@
     "proxay": "./dist/cli.js"
   },
   "jest": {
+    "reporters": ["default", "jest-junit"],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
@@ -67,6 +69,7 @@
     "@types/string-similarity": "^4.0.0",
     "express": "^4.17.1",
     "jest": "^25.5.4",
+    "jest-junit": "^16.0.0",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^25.5.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "start": "ts-node src/cli.ts",
     "start:hot": "ts-node-dev --respawn src/cli.ts",
-    "test": "jest",
-    "ci:test": "jest --ci",
+    "test": "jest --runInBand",
+    "ci:test": "jest --runInBand --ci",
     "build": "rm -rf dist && tsc",
     "lint:check": "yarn prettier:check && yarn tslint:check",
     "tslint:check": "tslint -p .",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,13 @@
     "start": "ts-node src/cli.ts",
     "start:hot": "ts-node-dev --respawn src/cli.ts",
     "test": "jest --runInBand",
-    "build": "rm -rf dist && tsc"
+    "build": "rm -rf dist && tsc",
+    "lint:check": "yarn prettier:check && yarn tslint:check",
+    "tslint:check": "tslint -p .",
+    "prettier:check": "prettier --list-different \"**/*.ts\"",
+    "lint:fix": "yarn prettier:fix && yarn tslint:fix",
+    "tslint:fix": "tslint -p . --fix",
+    "prettier:fix": "prettier --write \"**/*.ts\""
   },
   "bin": {
     "proxay": "./dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "proxay": "./dist/cli.js"
   },
   "jest": {
-    "reporters": ["default", "jest-junit"],
+    "reporters": [
+      "default",
+      "jest-junit"
+    ],
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
@@ -49,7 +52,7 @@
   "dependencies": {
     "assert-never": "^1.2.1",
     "axios": "^0.21.1",
-    "brotli": "^1.3.2",
+    "brotli": "^1.3.3",
     "chalk": "^4.1.0",
     "commander": "^6.2.0",
     "deep-diff": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,9 +1087,10 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-brotli@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.2.tgz#525a9cad4fcba96475d7d388f6aecb13eed52f46"
+brotli@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.3.tgz#7365d8cc00f12cf765d2b2c898716bcf4b604d48"
+  integrity sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==
   dependencies:
     base64-js "^1.1.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,6 +829,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -2433,6 +2438,16 @@ jest-jasmine2@^25.5.4:
     pretty-format "^25.5.0"
     throat "^5.0.0"
 
+jest-junit@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-16.0.0.tgz#d838e8c561cf9fdd7eb54f63020777eee4136785"
+  integrity sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz#2291c6294b0ce404241bb56fe60e2d0c3e34f0bb"
@@ -3916,6 +3931,13 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -4265,6 +4287,11 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-to-istanbul@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz#22fe35709a64955f49a08a7c7c959f6520ad6f20"
@@ -4397,6 +4424,11 @@ ws@^7.0.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
Various forms of CI improvements:
* Switch CircleCI setup to use executors and commands instead of ad-hoc YAML blocks.
* Generate Junit XML output of the unit tests and upload the test results to CircleCI.
* Run the tests across multiple versions of NodeJS.
  * I could not get the tests to pass on Node 20 currently, so I've excluded Node 20 for the moment.