### PR TITLE
[NT] Fix up CODEOWNERS and add explicit Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+* @airtasker/platform-services-core
+
+# Explicitly no codeowners for dependencies files.
+/package.json
+/yarn.lock

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "05:00"
+    timezone: Australia/Sydney
+  open-pull-requests-limit: 99

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,0 @@
-# Main squad: *Eng Effectiveness* (Tooling)
-# Main slack channel: #eng-effectiveness
-
-# Mainly targeting dependabot PRs with this. Trialing https://pullpanda.com/assigner
-# Please see commit message for more context
-/yarn.lock @airtasker/tooling-pullassigner


### PR DESCRIPTION
Codeowners currently points to a no-longer-existing team, and there's no explicit dependabot configuration.

This PR fixes both of those things, coping the setup from SPOT to this repo.