### PR TITLE
[NT] Bump `typescript` from 3.9.7 to 4.9.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "ts-node-dev": "^1.1.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.9.5"
   }
 }

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -64,10 +64,11 @@ export async function send(
     };
   } catch (e) {
     if (options.loggingEnabled) {
+      const errorCode = (e as Record<string, any>)?.code;
       console.error(
         chalk.red(
           `Could not send request ${request.method} ${request.path} (error: ${
-            e.code || "unknown"
+            errorCode || "unknown"
           })`
         )
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -171,7 +171,9 @@ export class RecordReplayServer {
    * Starts the server.
    */
   async start(port: number) {
-    await new Promise((resolve) => this.server.listen(port, resolve));
+    await new Promise((resolve) =>
+      this.server.listen(port, resolve as () => void)
+    );
   }
 
   /**
@@ -488,7 +490,7 @@ export class RecordReplayServer {
           return true;
         } catch (e) {
           if (this.loggingEnabled) {
-            console.warn(chalk.yellow(e.message));
+            console.warn(chalk.yellow((e as Error)?.message));
           }
           return false;
         }

--- a/src/tests/testserver.ts
+++ b/src/tests/testserver.ts
@@ -69,7 +69,7 @@ export class TestServer {
    */
   async start(port: number) {
     await new Promise(
-      (resolve) => (this.server = this.app.listen(port, resolve))
+      (resolve) => (this.server = this.app.listen(port, resolve as () => void))
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4239,10 +4239,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The version of TypeScript used in this repo is pretty ancient. This PR bumps it from a 3.x release to a 4.x release. Some explicit casts and downcasts were needed to be added as a result.