### PR TITLE
[NT] Use CircleCI `matrix` for running the same tests across different parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,17 +53,17 @@ commands:
 
 
 jobs:
-  test-node14:
+  run-tests-node-14:
     executor: node14
     steps:
       - run-tests
 
-  test-node16:
+  run-tests-node-16:
     executor: node16
     steps:
       - run-tests
 
-  test-node18:
+  run-tests-node-18:
     executor: node18
     steps:
       - run-tests
@@ -111,15 +111,11 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - test-node14:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - test-node16:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-      - test-node18:
+      - run-all-tests-across-supported-node-versions:
+          matrix:
+            name: run-tests-node-<< matrix.node-version >>
+            parameters:
+              node-version: ["14", "16", "18"]
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
@@ -133,9 +129,7 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
-            - test-node14
-            - test-node16
-            - test-node18
+            - run-all-tests-across-supported-node-versions
             - build-and-run
             - lint-check
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,19 @@
 version: 2.1
 
 executors:
-  node14:
+  node-14:
     docker:
       - image: cimg/node:14.21.3
     resource_class: small
     working_directory: ~/repo
 
-  node16:
+  node-16:
     docker:
       - image: cimg/node:16.20.1
     resource_class: small
     working_directory: ~/repo
 
-  node18:
+  node-18:
     docker:
       - image: cimg/node:18.18.1
     resource_class: small
@@ -53,23 +53,17 @@ commands:
 
 
 jobs:
-  run-tests-node-14:
-    executor: node14
-    steps:
-      - run-tests
-
-  run-tests-node-16:
-    executor: node16
-    steps:
-      - run-tests
-
-  run-tests-node-18:
-    executor: node18
+  run-tests:
+    parameters:
+      node-version:
+        type: string
+        description: The major version of NodeJS to use.
+    executor: node-<< parameters.node-version >>
     steps:
       - run-tests
 
   build-and-run:
-    executor: node14
+    executor: node-14
     steps:
       - checkout
       - install-dependencies
@@ -86,7 +80,7 @@ jobs:
           done
 
   lint-check:
-    executor: node14
+    executor: node-14
     steps:
       - checkout
       - install-dependencies
@@ -95,7 +89,7 @@ jobs:
           command: yarn lint:check
 
   publish:
-    executor: node14
+    executor: node-14
     steps:
       - checkout
       - install-dependencies
@@ -111,10 +105,8 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - run-all-tests-across-supported-node-versions:
+      - run-tests:
           matrix:
-            alias: run-all-tests-across-supported-node-versions
-            name: run-tests-node-<< matrix.node-version >>
             parameters:
               node-version: ["14", "16", "18"]
           filters:
@@ -130,7 +122,7 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - publish:
           requires:
-            - run-all-tests-across-supported-node-versions
+            - run-tests
             - build-and-run
             - lint-check
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,19 @@
 version: 2.1
 
 executors:
-  node-14:
+  node14:
     docker:
       - image: cimg/node:14.21.3
     resource_class: small
     working_directory: ~/repo
 
-  node-16:
+  node16:
     docker:
       - image: cimg/node:16.20.1
     resource_class: small
     working_directory: ~/repo
 
-  node-18:
+  node18:
     docker:
       - image: cimg/node:18.18.1
     resource_class: small
@@ -58,12 +58,12 @@ jobs:
       node-version:
         type: string
         description: The major version of NodeJS to use.
-    executor: node-<< parameters.node-version >>
+    executor: node<< parameters.node-version >>
     steps:
       - run-tests
 
   build-and-run:
-    executor: node-14
+    executor: node14
     steps:
       - checkout
       - install-dependencies
@@ -80,7 +80,7 @@ jobs:
           done
 
   lint-check:
-    executor: node-14
+    executor: node14
     steps:
       - checkout
       - install-dependencies
@@ -89,7 +89,7 @@ jobs:
           command: yarn lint:check
 
   publish:
-    executor: node-14
+    executor: node14
     steps:
       - checkout
       - install-dependencies
@@ -107,6 +107,7 @@ workflows:
     jobs:
       - run-tests:
           matrix:
+            name: test-node<< parameters.node-version >>
             parameters:
               node-version: ["14", "16", "18"]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ workflows:
     jobs:
       - run-all-tests-across-supported-node-versions:
           matrix:
+            alias: run-all-tests-across-supported-node-versions
             name: run-tests-node-<< matrix.node-version >>
             parameters:
               node-version: ["14", "16", "18"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,8 +106,8 @@ workflows:
   build-and-test:
     jobs:
       - run-tests:
+          name: test-node<< matrix.node-version >>
           matrix:
-            name: test-node<< parameters.node-version >>
             parameters:
               node-version: ["14", "16", "18"]
           filters:


### PR DESCRIPTION
Switch CI setup to utilise CircleCI `matrix` functionality for running a parameterised job across a cross-product of defined parameters, such as node versions. See https://circleci.com/docs/configuration-reference/#matrix for (sparse) documentation.