### PR TITLE
Ignore Headers / Send Proxy Port / Dump Matcher Fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ In replay mode, this same file will be read from your tapes directory.
 You can leverage this by picking a tape based on the current test's name in the `beforeEach`
 block of your test suite.
 
+## (Some) Options
+
+`--send-proxy-port`: This flag enables the forwarding of the Proxay's local port number to the proxied host in the host header. It is particularly useful for handling redirect issues where the proxied host needs to be aware of the port on which Proxay is running to construct accurate redirect URLs. This is similar to nginx' `proxy_set_header Host $host:$server_port;`.
+
+
+`--ignore-headers <headers>`: Allows users to specify a list of headers that should be ignored by Proxay's matching algorithm during request comparison. This is useful for bypassing headers that do not influence the behavior of the request but may cause mismatches, such as `x-forwarded-for` or `x-real-ip`. The headers should be provided as a comma-separated list.
+
+Note: there is already a hardcoded list of headers that get ignored:
+`accept`, `accept-encoding`, `age`, `cache-control`, `clear-site-data`, `connection`, `expires`, `from`, `host`, `postman-token`, `pragma`, `referer`, `referer-policy`, `te`, `trailer`, `transfer-encoding`, `user-agent`, `warning`, `x-datadog-trace-id`, `x-datadog-parent-id`, `traceparent`
+
+
+`-r, --redact-headers <headers>`: This option enables the redaction of specific HTTP header values, which are replaced by `XXXX` to maintain privacy or confidentiality during the recording of network interactions. The headers should be provided as a comma-separated list.
+
+
+`--dump-matcher-fails`: When exact request matching is enabled, this flag provides some debug information on why a request did not match any recorded tape. It is useful for troubleshooting and refining the conditions under which requests are considered equivalent, focusing on differences in headers and query parameters.
+
+
 ## Typical use case
 
 Let's say you're writing tests for your client. You want your tests to run as

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Note: there is already a hardcoded list of headers that get ignored:
 `-r, --redact-headers <headers>`: This option enables the redaction of specific HTTP header values, which are replaced by `XXXX` to maintain privacy or confidentiality during the recording of network interactions. The headers should be provided as a comma-separated list.
 
 
-`--dump-matcher-fails`: When exact request matching is enabled, this flag provides some debug information on why a request did not match any recorded tape. It is useful for troubleshooting and refining the conditions under which requests are considered equivalent, focusing on differences in headers and query parameters.
+`--debug-matcher-fails`: When exact request matching is enabled, this flag provides some debug information on why a request did not match any recorded tape. It is useful for troubleshooting and refining the conditions under which requests are considered equivalent, focusing on differences in headers and query parameters.
 
 
 ## Typical use case

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,10 @@ async function main(argv: string[]) {
     .option("-h, --host <host>", "Host to proxy (not required in replay mode)")
     .option("-p, --port <port>", "Local port to serve on", "3000")
     .option(
+      "--send-proxy-port",
+      "Sends the proxays port to the proxied host (helps for redirect issues)",
+    )
+    .option(
       "--exact-request-matching",
       "Perform exact request matching instead of best-effort request matching during replay.",
     )
@@ -105,6 +109,8 @@ async function main(argv: string[]) {
   const defaultTapeName: string = options.defaultTape;
   const host: string = options.host;
   const port = parseInt(options.port, 10);
+  const sendProxyPort: boolean =
+    options.sendProxyPort === undefined ? false : options.sendProxyPort;
   const redactHeaders: string[] = options.redactHeaders;
   const preventConditionalRequests: boolean =
     !!options.dropConditionalRequestHeaders;
@@ -168,6 +174,7 @@ async function main(argv: string[]) {
     initialMode,
     tapeDir,
     host,
+    proxyPortToSend: sendProxyPort ? port : undefined,
     defaultTapeName,
     enableLogging: true,
     redactHeaders,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,8 +66,8 @@ async function main(argv: string[]) {
       "Perform exact request matching instead of best-effort request matching during replay.",
     )
     .option(
-      "--dump-matcher-fails",
-      "In exact request matching mode, dumps information about failed matches for headers and queries.",
+      "--debug-matcher-fails",
+      "In exact request matching mode, shows debug information about failed matches for headers and queries.",
     )
     .option(
       "-r, --redact-headers <headers>",
@@ -123,8 +123,8 @@ async function main(argv: string[]) {
     options.exactRequestMatching === undefined
       ? false
       : options.exactRequestMatching;
-  const dumpMatcherFails: boolean =
-    options.dumpMatcherFails === undefined ? false : options.dumpMatcherFails;
+  const debugMatcherFails: boolean =
+    options.debugMatcherFails === undefined ? false : options.debugMatcherFails;
 
   switch (initialMode) {
     case "record":
@@ -164,9 +164,9 @@ async function main(argv: string[]) {
     }
   }
 
-  if (dumpMatcherFails && !exactRequestMatching) {
+  if (debugMatcherFails && !exactRequestMatching) {
     panic(
-      "The --dump-matcher-fails flag can only be used with the --exact-request-matching flag.",
+      "The --debug-matcher-fails flag can only be used with the --exact-request-matching flag.",
     );
   }
 
@@ -185,7 +185,7 @@ async function main(argv: string[]) {
     rewriteBeforeDiffRules,
     ignoreHeaders,
     exactRequestMatching,
-    dumpMatcherFails,
+    debugMatcherFails,
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,10 @@ async function main(argv: string[]) {
       "Perform exact request matching instead of best-effort request matching during replay.",
     )
     .option(
+      "--dump-matcher-fails",
+      "In exact request matching mode, dumps information about failed matches for headers and queries.",
+    )
+    .option(
       "-r, --redact-headers <headers>",
       "Request headers to redact (values will be replaced by XXXX)",
       commaSeparatedList,
@@ -113,6 +117,8 @@ async function main(argv: string[]) {
     options.exactRequestMatching === undefined
       ? false
       : options.exactRequestMatching;
+  const dumpMatcherFails: boolean =
+    options.dumpMatcherFails === undefined ? false : options.dumpMatcherFails;
 
   switch (initialMode) {
     case "record":
@@ -152,6 +158,12 @@ async function main(argv: string[]) {
     }
   }
 
+  if (dumpMatcherFails && !exactRequestMatching) {
+    panic(
+      "The --dump-matcher-fails flag can only be used with the --exact-request-matching flag.",
+    );
+  }
+
   const server = new RecordReplayServer({
     initialMode,
     tapeDir,
@@ -166,6 +178,7 @@ async function main(argv: string[]) {
     rewriteBeforeDiffRules,
     ignoreHeaders,
     exactRequestMatching,
+    dumpMatcherFails,
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ async function main(argv: string[]) {
     )
     .option(
       "-r, --redact-headers <headers>",
-      "Request headers to redact",
+      "Request headers to redact (values will be replaced by XXXX)",
       commaSeparatedList,
     )
     .option(
@@ -88,6 +88,11 @@ async function main(argv: string[]) {
       rewriteRule,
       new RewriteRules(),
     )
+    .option(
+      "--ignore-headers <headers>",
+      "Save headers to be ignored for the matching algorithm",
+      commaSeparatedList,
+    )
     .parse(argv);
 
   const options = program.opts();
@@ -103,6 +108,7 @@ async function main(argv: string[]) {
   const httpsKey: string = options.httpsKey;
   const httpsCert: string = options.httpsCert;
   const rewriteBeforeDiffRules: RewriteRules = options.rewriteBeforeDiff;
+  const ignoreHeaders: string[] = options.ignoreHeaders;
   const exactRequestMatching: boolean =
     options.exactRequestMatching === undefined
       ? false
@@ -158,6 +164,7 @@ async function main(argv: string[]) {
     httpsKey,
     httpsCert,
     rewriteBeforeDiffRules,
+    ignoreHeaders,
     exactRequestMatching,
   });
   await server.start(port);

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -48,7 +48,7 @@ export function findRecordMatches(
   tapeRecords: TapeRecord[],
   rewriteBeforeDiffRules: RewriteRules,
   exactRequestMatching: boolean,
-  dumpMatcherFails: boolean,
+  debugMatcherFails: boolean,
   ignoreHeaders: string[],
 ): TapeRecord[] {
   let bestSimilarityScore = +Infinity;
@@ -62,7 +62,7 @@ export function findRecordMatches(
       potentialMatch,
       rewriteBeforeDiffRules,
       ignoreHeaders,
-      dumpMatcherFails,
+      debugMatcherFails,
     );
 
     if (similarityScore < bestSimilarityScore) {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -48,6 +48,7 @@ export function findRecordMatches(
   tapeRecords: TapeRecord[],
   rewriteBeforeDiffRules: RewriteRules,
   exactRequestMatching: boolean,
+  ignoreHeaders: string[],
 ): TapeRecord[] {
   let bestSimilarityScore = +Infinity;
   if (exactRequestMatching) {
@@ -59,6 +60,7 @@ export function findRecordMatches(
       request,
       potentialMatch,
       rewriteBeforeDiffRules,
+      ignoreHeaders,
     );
 
     if (similarityScore < bestSimilarityScore) {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -48,6 +48,7 @@ export function findRecordMatches(
   tapeRecords: TapeRecord[],
   rewriteBeforeDiffRules: RewriteRules,
   exactRequestMatching: boolean,
+  dumpMatcherFails: boolean,
   ignoreHeaders: string[],
 ): TapeRecord[] {
   let bestSimilarityScore = +Infinity;
@@ -61,6 +62,7 @@ export function findRecordMatches(
       potentialMatch,
       rewriteBeforeDiffRules,
       ignoreHeaders,
+      dumpMatcherFails,
     );
 
     if (similarityScore < bestSimilarityScore) {

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -13,6 +13,7 @@ export async function send(
   options: {
     loggingEnabled?: boolean;
     timeout?: number;
+    proxyPortToSend?: number;
   },
 ): Promise<TapeRecord> {
   try {
@@ -27,7 +28,9 @@ export async function send(
           port,
           headers: {
             ...request.headers,
-            host: hostname,
+            host:
+              hostname +
+              (options.proxyPortToSend ? `:${options.proxyPortToSend}` : ""),
           },
           timeout: options.timeout,
         };

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ export class RecordReplayServer {
 
   private mode: Mode;
   private proxiedHost?: string;
+  private proxyPortToSend?: number;
   private timeout: number;
   private currentTapeRecords: TapeRecord[] = [];
   private currentTape!: string;
@@ -39,6 +40,7 @@ export class RecordReplayServer {
     tapeDir: string;
     defaultTapeName: string;
     host?: string;
+    proxyPortToSend?: number;
     timeout?: number;
     enableLogging?: boolean;
     redactHeaders?: string[];
@@ -54,6 +56,7 @@ export class RecordReplayServer {
     this.currentTapeRecords = [];
     this.mode = options.initialMode;
     this.proxiedHost = options.host;
+    this.proxyPortToSend = options.proxyPortToSend;
     this.timeout = options.timeout || 5000;
     this.loggingEnabled = options.enableLogging || false;
     const redactHeaders = options.redactHeaders || [];
@@ -340,6 +343,7 @@ export class RecordReplayServer {
       {
         loggingEnabled: this.loggingEnabled,
         timeout: this.timeout,
+        proxyPortToSend: this.proxyPortToSend,
       },
     );
     this.addRecordToTape(record);
@@ -386,6 +390,7 @@ export class RecordReplayServer {
         {
           loggingEnabled: this.loggingEnabled,
           timeout: this.timeout,
+          proxyPortToSend: this.proxyPortToSend,
         },
       );
       this.addRecordToTape(record);
@@ -416,6 +421,7 @@ export class RecordReplayServer {
       {
         loggingEnabled: this.loggingEnabled,
         timeout: this.timeout,
+        proxyPortToSend: this.proxyPortToSend,
       },
     );
     if (this.loggingEnabled) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ export class RecordReplayServer {
   private rewriteBeforeDiffRules: RewriteRules;
   private ignoreHeaders: string[];
   private exactRequestMatching: boolean;
+  private dumpMatcherFails: boolean;
 
   constructor(options: {
     initialMode: Mode;
@@ -48,6 +49,7 @@ export class RecordReplayServer {
     rewriteBeforeDiffRules?: RewriteRules;
     ignoreHeaders?: string[];
     exactRequestMatching?: boolean;
+    dumpMatcherFails?: boolean;
   }) {
     this.currentTapeRecords = [];
     this.mode = options.initialMode;
@@ -65,6 +67,8 @@ export class RecordReplayServer {
       options.exactRequestMatching === undefined
         ? false
         : options.exactRequestMatching;
+    this.dumpMatcherFails =
+      options.dumpMatcherFails === undefined ? false : options.dumpMatcherFails;
     this.loadTape(this.defaultTape);
 
     const handler = async (
@@ -294,6 +298,7 @@ export class RecordReplayServer {
         this.currentTapeRecords,
         this.rewriteBeforeDiffRules,
         this.exactRequestMatching,
+        this.dumpMatcherFails,
         this.ignoreHeaders,
       ),
       this.replayedTapes,
@@ -356,6 +361,7 @@ export class RecordReplayServer {
         this.currentTapeRecords,
         this.rewriteBeforeDiffRules,
         this.exactRequestMatching,
+        this.dumpMatcherFails,
         this.ignoreHeaders,
       ),
       this.replayedTapes,

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,7 @@ export class RecordReplayServer {
   private rewriteBeforeDiffRules: RewriteRules;
   private ignoreHeaders: string[];
   private exactRequestMatching: boolean;
-  private dumpMatcherFails: boolean;
+  private debugMatcherFails: boolean;
 
   constructor(options: {
     initialMode: Mode;
@@ -51,7 +51,7 @@ export class RecordReplayServer {
     rewriteBeforeDiffRules?: RewriteRules;
     ignoreHeaders?: string[];
     exactRequestMatching?: boolean;
-    dumpMatcherFails?: boolean;
+    debugMatcherFails?: boolean;
   }) {
     this.currentTapeRecords = [];
     this.mode = options.initialMode;
@@ -70,8 +70,10 @@ export class RecordReplayServer {
       options.exactRequestMatching === undefined
         ? false
         : options.exactRequestMatching;
-    this.dumpMatcherFails =
-      options.dumpMatcherFails === undefined ? false : options.dumpMatcherFails;
+    this.debugMatcherFails =
+      options.debugMatcherFails === undefined
+        ? false
+        : options.debugMatcherFails;
     this.loadTape(this.defaultTape);
 
     const handler = async (
@@ -301,7 +303,7 @@ export class RecordReplayServer {
         this.currentTapeRecords,
         this.rewriteBeforeDiffRules,
         this.exactRequestMatching,
-        this.dumpMatcherFails,
+        this.debugMatcherFails,
         this.ignoreHeaders,
       ),
       this.replayedTapes,
@@ -365,7 +367,7 @@ export class RecordReplayServer {
         this.currentTapeRecords,
         this.rewriteBeforeDiffRules,
         this.exactRequestMatching,
-        this.dumpMatcherFails,
+        this.debugMatcherFails,
         this.ignoreHeaders,
       ),
       this.replayedTapes,

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ export class RecordReplayServer {
   private replayedTapes: Set<TapeRecord> = new Set();
   private preventConditionalRequests?: boolean;
   private rewriteBeforeDiffRules: RewriteRules;
+  private ignoreHeaders: string[];
   private exactRequestMatching: boolean;
 
   constructor(options: {
@@ -45,6 +46,7 @@ export class RecordReplayServer {
     httpsKey?: string;
     httpsCert?: string;
     rewriteBeforeDiffRules?: RewriteRules;
+    ignoreHeaders?: string[];
     exactRequestMatching?: boolean;
   }) {
     this.currentTapeRecords = [];
@@ -58,6 +60,7 @@ export class RecordReplayServer {
     this.preventConditionalRequests = options.preventConditionalRequests;
     this.rewriteBeforeDiffRules =
       options.rewriteBeforeDiffRules || new RewriteRules();
+    this.ignoreHeaders = options.ignoreHeaders || [];
     this.exactRequestMatching =
       options.exactRequestMatching === undefined
         ? false
@@ -291,6 +294,7 @@ export class RecordReplayServer {
         this.currentTapeRecords,
         this.rewriteBeforeDiffRules,
         this.exactRequestMatching,
+        this.ignoreHeaders,
       ),
       this.replayedTapes,
     );
@@ -352,6 +356,7 @@ export class RecordReplayServer {
         this.currentTapeRecords,
         this.rewriteBeforeDiffRules,
         this.exactRequestMatching,
+        this.ignoreHeaders,
       ),
       this.replayedTapes,
     );

--- a/src/similarity.spec.ts
+++ b/src/similarity.spec.ts
@@ -290,6 +290,71 @@ describe("similarity", () => {
     ).toBe(1);
   });
 
+  it("counts headers differences (ignoring specified ones)", () => {
+    expect(
+      computeSimilarity(
+        {
+          method: "POST",
+          path: "/test",
+          headers: {
+            one: "one",
+            two: "two",
+            three: "three",
+            four: "four",
+          },
+          body: Buffer.from([]),
+        },
+        {
+          request: {
+            method: "POST",
+            path: "/test",
+            headers: {
+              // one is missing
+              two: "different two",
+              three: "different three",
+              four: "four", // four is the same
+            },
+            body: Buffer.from([]),
+          },
+          response: DUMMY_RESPONSE,
+        },
+        new RewriteRules(),
+        ["one", "two", "three"],
+      ),
+    ).toBe(0);
+    expect(
+      computeSimilarity(
+        {
+          method: "POST",
+          path: "/test",
+          headers: {
+            one: "one",
+            two: "two",
+            three: "three",
+            four: "four",
+          },
+          body: Buffer.from([]),
+        },
+        {
+          request: {
+            method: "POST",
+            path: "/test",
+            headers: {
+              // one is missing
+              two: "different two",
+              three: "different three",
+              four: "different four",
+            },
+            body: Buffer.from([]),
+          },
+          response: DUMMY_RESPONSE,
+        },
+        new RewriteRules(),
+        ["one", "two", "three"],
+      ),
+    ).toBe(1);
+  });
+
   describe("JSON payload types", () => {
     it("reports no differences when the paylods are the same", () => {
       // The following payloads are identical, but formatted differently.

--- a/src/similarity.spec.ts
+++ b/src/similarity.spec.ts
@@ -427,7 +427,7 @@ describe("similarity", () => {
     );
 
     expect(logSpy).toHaveBeenCalledWith(
-      'dump: a: {"one":"one","two":"two","three":"three","four":"four"} / b: {"two":"different two","three":"different three","four":"four"}',
+      'debug: a: {"one":"one","two":"two","three":"three","four":"four"} / b: {"two":"different two","three":"different three","four":"four"}',
     );
 
     logSpy.mockRestore();

--- a/src/similarity.spec.ts
+++ b/src/similarity.spec.ts
@@ -31,6 +31,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(0);
   });
@@ -54,6 +55,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(Infinity);
   });
@@ -77,6 +79,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(Infinity);
   });
@@ -100,6 +103,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(1);
     expect(
@@ -120,6 +124,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(1);
     expect(
@@ -140,6 +145,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(2);
     expect(
@@ -160,6 +166,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(0);
     expect(
@@ -180,6 +187,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(1);
   });
@@ -214,6 +222,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(0);
     expect(
@@ -244,6 +253,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(1);
     expect(
@@ -275,6 +285,7 @@ describe("similarity", () => {
           response: DUMMY_RESPONSE,
         },
         new RewriteRules(),
+        [],
       ),
     ).toBe(1);
   });
@@ -312,6 +323,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(0);
     });
@@ -351,6 +363,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(1);
 
@@ -385,6 +398,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(6);
 
@@ -425,6 +439,7 @@ describe("similarity", () => {
               "$1",
             ),
           ),
+          [],
         ),
       ).toBe(0);
     });
@@ -454,6 +469,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(0);
     });
@@ -481,6 +497,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(6);
     });
@@ -517,6 +534,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(0);
     });
@@ -544,6 +562,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(5149);
     });
@@ -591,6 +610,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(0);
     });
@@ -655,6 +675,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(1);
     });
@@ -724,6 +745,7 @@ describe("similarity", () => {
               "$1",
             ),
           ),
+          [],
         ),
       ).toBe(0);
     });
@@ -756,6 +778,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(0);
     });
@@ -788,6 +811,7 @@ describe("similarity", () => {
             response: DUMMY_RESPONSE,
           },
           new RewriteRules(),
+          [],
         ),
       ).toBe(1);
     });
@@ -825,6 +849,7 @@ describe("similarity", () => {
               "$1",
             ),
           ),
+          [],
         ),
       ).toBe(0);
     });

--- a/src/similarity.spec.ts
+++ b/src/similarity.spec.ts
@@ -355,6 +355,84 @@ describe("similarity", () => {
     ).toBe(1);
   });
 
+  it("dumps headers if non equal", () => {
+    const logSpy = jest.spyOn(console, "log");
+
+    computeSimilarity(
+      {
+        method: "POST",
+        path: "/test",
+        headers: {
+          ignore: "ignore",
+          one: "one",
+          two: "two",
+          three: "three",
+          four: "four",
+        },
+        body: Buffer.from([]),
+      },
+      {
+        request: {
+          method: "POST",
+          path: "/test",
+          headers: {
+            ignore: "different ignore",
+            one: "one",
+            two: "two",
+            three: "three",
+            four: "four",
+          },
+          body: Buffer.from([]),
+        },
+        response: DUMMY_RESPONSE,
+      },
+      new RewriteRules(),
+      ["ignore"],
+      true,
+    );
+
+    expect(logSpy).not.toHaveBeenCalled();
+
+    computeSimilarity(
+      {
+        method: "POST",
+        path: "/test",
+        headers: {
+          ignore: "ignore",
+          one: "one",
+          two: "two",
+          three: "three",
+          four: "four",
+        },
+        body: Buffer.from([]),
+      },
+      {
+        request: {
+          method: "POST",
+          path: "/test",
+          headers: {
+            ignore: "different ignore",
+            // one is missing
+            two: "different two",
+            three: "different three",
+            four: "four", // four is the same
+          },
+          body: Buffer.from([]),
+        },
+        response: DUMMY_RESPONSE,
+      },
+      new RewriteRules(),
+      ["ignore"],
+      true,
+    );
+
+    expect(logSpy).toHaveBeenCalledWith(
+      'dump: a: {"one":"one","two":"two","three":"three","four":"four"} / b: {"two":"different two","three":"different three","four":"four"}',
+    );
+
+    logSpy.mockRestore();
+  });
+
   describe("JSON payload types", () => {
     it("reports no differences when the paylods are the same", () => {
       // The following payloads are identical, but formatted differently.

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -363,7 +363,7 @@ function stripExtraneousHeaders(
         // Ignore.
         continue;
       default:
-        if (!ignoreHeaders.includes(key))
+        if (!ignoreHeaders.find((header) => header === key)) {
           safeHeaders[key] = headers[key];
         }
     }

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -363,7 +363,7 @@ function stripExtraneousHeaders(
         // Ignore.
         continue;
       default:
-        if (!ignoreHeaders.find((header) => header === key)) {
+        if (!ignoreHeaders.includes(key))
           safeHeaders[key] = headers[key];
         }
     }

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -28,7 +28,7 @@ export function computeSimilarity(
   compareTo: TapeRecord,
   rewriteBeforeDiffRules: RewriteRules,
   ignoreHeaders: string[],
-  dumpMatcherFails: boolean = false,
+  debugMatcherFails: boolean = false,
 ): number {
   // If the HTTP method is different, no match.
   if (request.method !== compareTo.request.method) {
@@ -52,7 +52,7 @@ export function computeSimilarity(
     parsedQueryParameters,
     parsedCompareToQueryParameters,
     rewriteBeforeDiffRules,
-    dumpMatcherFails,
+    debugMatcherFails,
   );
 
   // Compare the cleaned headers.
@@ -65,7 +65,7 @@ export function computeSimilarity(
     cleanedHeaders,
     cleanedCompareToHeaders,
     rewriteBeforeDiffRules,
-    dumpMatcherFails,
+    debugMatcherFails,
   );
 
   // Compare the bodies.
@@ -74,8 +74,8 @@ export function computeSimilarity(
     compareTo.request,
     rewriteBeforeDiffRules,
   );
-  if (dumpMatcherFails && differencesBody > 0) {
-    console.log(`dump: body is different`);
+  if (debugMatcherFails && differencesBody > 0) {
+    console.log(`debug: body is different`);
   }
 
   return differencesQueryParameters + differencesHeaders + differencesBody;
@@ -275,15 +275,15 @@ function countObjectDifferences(
   a: object,
   b: object,
   rewriteRules: RewriteRules,
-  dumpMatcherFails: boolean = false,
+  debugMatcherFails: boolean = false,
 ): number {
   a = rewriteRules.apply(a);
   b = rewriteRules.apply(b);
 
   const result = (diff(a, b) || []).length;
 
-  if (dumpMatcherFails && result > 0) {
-    console.log(`dump: a: ${JSON.stringify(a)} / b: ${JSON.stringify(b)}`);
+  if (debugMatcherFails && result > 0) {
+    console.log(`debug: a: ${JSON.stringify(a)} / b: ${JSON.stringify(b)}`);
   }
 
   return result;

--- a/src/similarity.ts
+++ b/src/similarity.ts
@@ -28,6 +28,7 @@ export function computeSimilarity(
   compareTo: TapeRecord,
   rewriteBeforeDiffRules: RewriteRules,
   ignoreHeaders: string[],
+  dumpMatcherFails: boolean = false,
 ): number {
   // If the HTTP method is different, no match.
   if (request.method !== compareTo.request.method) {
@@ -51,6 +52,7 @@ export function computeSimilarity(
     parsedQueryParameters,
     parsedCompareToQueryParameters,
     rewriteBeforeDiffRules,
+    dumpMatcherFails,
   );
 
   // Compare the cleaned headers.
@@ -63,6 +65,7 @@ export function computeSimilarity(
     cleanedHeaders,
     cleanedCompareToHeaders,
     rewriteBeforeDiffRules,
+    dumpMatcherFails,
   );
 
   // Compare the bodies.
@@ -71,6 +74,9 @@ export function computeSimilarity(
     compareTo.request,
     rewriteBeforeDiffRules,
   );
+  if (dumpMatcherFails && differencesBody > 0) {
+    console.log(`dump: body is different`);
+  }
 
   return differencesQueryParameters + differencesHeaders + differencesBody;
 }
@@ -269,11 +275,18 @@ function countObjectDifferences(
   a: object,
   b: object,
   rewriteRules: RewriteRules,
+  dumpMatcherFails: boolean = false,
 ): number {
   a = rewriteRules.apply(a);
   b = rewriteRules.apply(b);
 
-  return (diff(a, b) || []).length;
+  const result = (diff(a, b) || []).length;
+
+  if (dumpMatcherFails && result > 0) {
+    console.log(`dump: a: ${JSON.stringify(a)} / b: ${JSON.stringify(b)}`);
+  }
+
+  return result;
 }
 
 /**

--- a/src/tests/send-proxy-port.spec.ts
+++ b/src/tests/send-proxy-port.spec.ts
@@ -1,0 +1,22 @@
+import { setupServers } from "./setup";
+import axios from "axios";
+import { PROXAY_HOST, PROXAY_PORT } from "./config";
+import { JSON_IDENTITY_PATH } from "./testserver";
+
+describe("SendProxyPort", () => {
+  describe("regular sendProxyPort mode", () => {
+    setupServers({ mode: "passthrough" });
+    test("response: hostname without port", async () => {
+      const response = await axios.get(`${PROXAY_HOST}${JSON_IDENTITY_PATH}`);
+      expect(response.data.hostname).toBe("localhost");
+    });
+  });
+
+  describe("regular sendProxyPort mode", () => {
+    setupServers({ mode: "passthrough", sendProxyPort: true });
+    test("response: hostname with port", async () => {
+      const response = await axios.get(`${PROXAY_HOST}${JSON_IDENTITY_PATH}`);
+      expect(response.data.hostname).toBe("localhost:" + PROXAY_PORT);
+    });
+  });
+});

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -10,11 +10,13 @@ export function setupServers({
   tapeDirName = mode,
   defaultTapeName = "default",
   exactRequestMatching,
+  sendProxyPort = false,
 }: {
   mode: Mode;
   tapeDirName?: string;
   defaultTapeName?: string;
   exactRequestMatching?: boolean;
+  sendProxyPort?: boolean;
 }) {
   const tapeDir = path.join(__dirname, "tapes", tapeDirName);
   const servers = { tapeDir } as {
@@ -39,6 +41,7 @@ export function setupServers({
       timeout: 100,
       enableLogging: true,
       exactRequestMatching,
+      proxyPortToSend: sendProxyPort ? PROXAY_PORT : undefined,
     });
     await Promise.all([
       servers.proxy.start(PROXAY_PORT),

--- a/src/tests/testserver.ts
+++ b/src/tests/testserver.ts
@@ -41,7 +41,11 @@ export class TestServer {
       res.send(BINARY_RESPONSE);
     });
     this.app.get(JSON_IDENTITY_PATH, (req, res) => {
-      res.json({ data: req.path, requestCount: this.requestCount });
+      res.json({
+        data: req.path,
+        requestCount: this.requestCount,
+        hostname: req.header("host"),
+      });
     });
     this.app.post(JSON_IDENTITY_PATH, (req, res) => {
       res.json({ ...req.body, requestCount: this.requestCount });


### PR DESCRIPTION
I added three flags that are needed in my situation and might be helpful for others:

`--ignore-headers`: Allows users to specify a list of headers that should be ignored by Proxay. This is especially useful together with the `--exact-request-matching` flag.

`--send-proxy-port`: Sends the proxays port to the proxied host, similar to nginx' `proxy_set_header Host $host:$server_port;`. This helps against redirect issues.

`--dump-matcher-fails`: Dumps the headers from the current and recorded request, if they are not matching. This helps to find headers that should be ignored in the specific situation.

For all three parts there are simple tests. I also added a paragraph in the Readme that documents those flags.