### PR TITLE
feat(SSE-77): add --omit-empty-tapes flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Note: there is already a hardcoded list of headers that get ignored:
 `--debug-matcher-fails`: When exact request matching is enabled, this flag provides some debug information on why a request did not match any recorded tape. It is useful for troubleshooting and refining the conditions under which requests are considered equivalent, focusing on differences in headers and query parameters.
 
 
+`--omit-empty-tapes`: When enabled, Proxay will not write tape files that contain no recorded interactions. This is useful when running multiple Proxay instances in parallel (e.g. one per backend service), where many instances may receive no traffic for a given test and would otherwise produce empty `http_interactions: []` files.
+
+In replay mode, a missing tape file is treated as empty rather than an error — the tape is loaded successfully with no interactions, and any requests against it return no response (the same behaviour as a recorded tape with no matching entries). This means you do not need to pre-create tape files for backends that a given test never calls.
+
+
 ## Typical use case
 
 Let's say you're writing tests for your client. You want your tests to run as

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,8 +48,7 @@ function rewriteRule(value: string, rewriteRules: RewriteRules): RewriteRules {
 }
 
 export async function main(argv: string[]) {
-  const program = new Command();
-  program
+  const program = new Command()
     .option("-m, --mode <mode>", "Mode (record, replay or passthrough)")
     .option(
       "-t, --tapes-dir <tapes-dir>",
@@ -156,7 +155,9 @@ export async function main(argv: string[]) {
 
   if (initialMode === "replay" && !fs.existsSync(tapeDir)) {
     if (omitEmptyTapes) {
-      console.info(`No tapes directory found at ${tapeDir}, treating all tapes as empty (--omit-empty-tapes).`);
+      console.info(
+        `No tapes directory found at ${tapeDir}, treating all tapes as empty (--omit-empty-tapes).`,
+      );
     } else {
       panic(
         `No tapes found at ${tapeDir}. Did you mean to start in record mode?`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import chalk from "chalk";
-import { program } from "commander";
+import { Command } from "commander";
 import fs from "fs-extra";
 import { RewriteRule, RewriteRules } from "./rewrite";
 import { RecordReplayServer } from "./server";
@@ -47,7 +47,8 @@ function rewriteRule(value: string, rewriteRules: RewriteRules): RewriteRules {
   return rewriteRules.appendRule(rule);
 }
 
-async function main(argv: string[]) {
+export async function main(argv: string[]) {
+  const program = new Command();
   program
     .option("-m, --mode <mode>", "Mode (record, replay or passthrough)")
     .option(
@@ -106,6 +107,10 @@ async function main(argv: string[]) {
       "Save headers to be ignored for the matching algorithm",
       commaSeparatedList,
     )
+    .option(
+      "--omit-empty-tapes",
+      "Do not write tape files when no interactions were recorded. In replay mode, treat a missing tape as empty rather than an error.",
+    )
     .parse(argv);
 
   const options = program.opts();
@@ -131,6 +136,7 @@ async function main(argv: string[]) {
       : options.exactRequestMatching;
   const debugMatcherFails: boolean =
     options.debugMatcherFails === undefined ? false : options.debugMatcherFails;
+  const omitEmptyTapes: boolean = !!options.omitEmptyTapes;
 
   switch (initialMode) {
     case "record":
@@ -149,9 +155,13 @@ async function main(argv: string[]) {
   }
 
   if (initialMode === "replay" && !fs.existsSync(tapeDir)) {
-    panic(
-      `No tapes found at ${tapeDir}. Did you mean to start in record mode?`,
-    );
+    if (omitEmptyTapes) {
+      console.info(`No tapes directory found at ${tapeDir}, treating all tapes as empty (--omit-empty-tapes).`);
+    } else {
+      panic(
+        `No tapes found at ${tapeDir}. Did you mean to start in record mode?`,
+      );
+    }
   }
 
   if (preventConditionalRequests && initialMode === "record") {
@@ -193,9 +203,11 @@ async function main(argv: string[]) {
     ignoreHeaders,
     exactRequestMatching,
     debugMatcherFails,
+    omitEmptyTapes,
   });
   await server.start(port);
   console.log(chalk.green(`Proxying in ${initialMode} mode on port ${port}.`));
+  return server;
 }
 
 function panic(message: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ function rewriteRule(value: string, rewriteRules: RewriteRules): RewriteRules {
   return rewriteRules.appendRule(rule);
 }
 
-export async function main(argv: string[]) {
+export async function main(argv: string[]): Promise<RecordReplayServer> {
   const program = new Command()
     .option("-m, --mode <mode>", "Mode (record, replay or passthrough)")
     .option(
@@ -155,7 +155,7 @@ export async function main(argv: string[]) {
 
   if (initialMode === "replay" && !fs.existsSync(tapeDir)) {
     if (omitEmptyTapes) {
-      console.info(
+      console.log(
         `No tapes directory found at ${tapeDir}, treating all tapes as empty (--omit-empty-tapes).`,
       );
     } else {

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -65,6 +65,13 @@ export class Persistence {
   }
 
   /**
+   * Returns whether a tape file exists on disk.
+   */
+  tapeExistsOnDisk(tapeName: string): boolean {
+    return fs.existsSync(this.getTapePath(tapeName));
+  }
+
+  /**
    * Deletes the tape file from disk if it exists.
    */
   deleteTapeFromDisk(tapeName: string) {

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -64,6 +64,16 @@ export class Persistence {
     return persistedTapeRecords.map(reviveTape);
   }
 
+  /**
+   * Deletes the tape file from disk if it exists.
+   */
+  deleteTapeFromDisk(tapeName: string) {
+    const tapePath = this.getTapePath(tapeName);
+    if (fs.existsSync(tapePath)) {
+      fs.removeSync(tapePath);
+    }
+  }
+
   isTapeNameValid(tapeName: string): boolean {
     return !path
       .relative(this.tapeDir, path.join(this.tapeDir, tapeName))

--- a/src/server.ts
+++ b/src/server.ts
@@ -462,40 +462,46 @@ export class RecordReplayServer {
         }
         return true;
       case "replay":
+        if (
+          this.omitEmptyTapes &&
+          !this.persistence.tapeExistsOnDisk(this.currentTape)
+        ) {
+          this.currentTapeRecords = [];
+          if (this.loggingEnabled) {
+            console.log(
+              chalk.blueBright(
+                `No tape found for ${this.currentTape}, treating as empty (--omit-empty-tapes).`,
+              ),
+            );
+          }
+          return true;
+        }
         try {
           this.currentTapeRecords = this.persistence.loadTapeFromDisk(
             this.currentTape,
           );
           return true;
         } catch (e) {
-          if (this.omitEmptyTapes) {
-            this.currentTapeRecords = [];
-            if (this.loggingEnabled) {
-              console.log(
-                chalk.blueBright(
-                  `No tape found for ${this.currentTape}, treating as empty (--omit-empty-tapes).`,
-                ),
-              );
-            }
-            return true;
-          }
           if (this.loggingEnabled) {
             console.warn(chalk.yellow((e as Error)?.message));
           }
           return false;
         }
       case "mimic":
+        if (
+          this.omitEmptyTapes &&
+          !this.persistence.tapeExistsOnDisk(this.currentTape)
+        ) {
+          this.currentTapeRecords = [];
+          return true;
+        }
         try {
           this.currentTapeRecords = this.persistence.loadTapeFromDisk(
             this.currentTape,
           );
         } catch (e) {
           this.currentTapeRecords = [];
-          if (this.omitEmptyTapes) {
-            this.persistence.deleteTapeFromDisk(this.currentTape);
-          } else {
-            this.persistence.saveTapeToDisk(this.currentTape, []);
-          }
+          this.persistence.saveTapeToDisk(this.currentTape, []);
         }
         return true;
       case "passthrough":

--- a/src/server.ts
+++ b/src/server.ts
@@ -444,7 +444,8 @@ export class RecordReplayServer {
   /**
    * Loads a specific tape into memory (erasing it in record mode).
    *
-   * @returns Whether the tape was found or not (always true in record/mimic mode).
+   * @returns Whether the tape was found or not (always true in record/mimic/passthrough
+   * modes, and in replay mode when omitEmptyTapes is set).
    */
   private loadTape(tapeName: string): boolean {
     this.currentTape = tapeName;
@@ -454,7 +455,9 @@ export class RecordReplayServer {
     switch (this.mode) {
       case "record":
         this.currentTapeRecords = [];
-        if (!this.omitEmptyTapes) {
+        if (this.omitEmptyTapes) {
+          this.persistence.deleteTapeFromDisk(this.currentTape);
+        } else {
           this.persistence.saveTapeToDisk(this.currentTape, []);
         }
         return true;
@@ -488,7 +491,9 @@ export class RecordReplayServer {
           );
         } catch (e) {
           this.currentTapeRecords = [];
-          if (!this.omitEmptyTapes) {
+          if (this.omitEmptyTapes) {
+            this.persistence.deleteTapeFromDisk(this.currentTape);
+          } else {
             this.persistence.saveTapeToDisk(this.currentTape, []);
           }
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ export class RecordReplayServer {
   private ignoreHeaders: string[];
   private exactRequestMatching: boolean;
   private debugMatcherFails: boolean;
+  private omitEmptyTapes: boolean;
 
   constructor(options: {
     initialMode: Mode;
@@ -53,6 +54,7 @@ export class RecordReplayServer {
     ignoreHeaders?: string[];
     exactRequestMatching?: boolean;
     debugMatcherFails?: boolean;
+    omitEmptyTapes?: boolean;
   }) {
     this.currentTapeRecords = [];
     this.mode = options.initialMode;
@@ -80,6 +82,7 @@ export class RecordReplayServer {
       options.debugMatcherFails === undefined
         ? false
         : options.debugMatcherFails;
+    this.omitEmptyTapes = options.omitEmptyTapes || false;
     this.loadTape(this.defaultTape);
 
     const handler = async (
@@ -451,7 +454,9 @@ export class RecordReplayServer {
     switch (this.mode) {
       case "record":
         this.currentTapeRecords = [];
-        this.persistence.saveTapeToDisk(this.currentTape, []);
+        if (!this.omitEmptyTapes) {
+          this.persistence.saveTapeToDisk(this.currentTape, []);
+        }
         return true;
       case "replay":
         try {
@@ -460,6 +465,17 @@ export class RecordReplayServer {
           );
           return true;
         } catch (e) {
+          if (this.omitEmptyTapes) {
+            this.currentTapeRecords = [];
+            if (this.loggingEnabled) {
+              console.log(
+                chalk.blueBright(
+                  `No tape found for ${this.currentTape}, treating as empty (--omit-empty-tapes).`,
+                ),
+              );
+            }
+            return true;
+          }
           if (this.loggingEnabled) {
             console.warn(chalk.yellow((e as Error)?.message));
           }
@@ -472,7 +488,9 @@ export class RecordReplayServer {
           );
         } catch (e) {
           this.currentTapeRecords = [];
-          this.persistence.saveTapeToDisk(this.currentTape, []);
+          if (!this.omitEmptyTapes) {
+            this.persistence.saveTapeToDisk(this.currentTape, []);
+          }
         }
         return true;
       case "passthrough":

--- a/src/tests/cli.spec.ts
+++ b/src/tests/cli.spec.ts
@@ -8,7 +8,7 @@ describe("CLI — --omit-empty-tapes with missing tapes directory", () => {
     const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");
     });
-    const infoSpy = jest.spyOn(console, "info").mockImplementation(jest.fn());
+    const logSpy = jest.spyOn(console, "log").mockImplementation(jest.fn());
     try {
       const server = await main([
         "node",
@@ -21,9 +21,9 @@ describe("CLI — --omit-empty-tapes with missing tapes directory", () => {
         "3097",
         "--omit-empty-tapes",
       ]);
-      await server!.stop();
+      await server.stop();
 
-      expect(infoSpy).toHaveBeenCalledWith(
+      expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           "treating all tapes as empty (--omit-empty-tapes)",
         ),
@@ -31,7 +31,7 @@ describe("CLI — --omit-empty-tapes with missing tapes directory", () => {
       expect(exitSpy).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();
-      infoSpy.mockRestore();
+      logSpy.mockRestore();
     }
   });
 

--- a/src/tests/cli.spec.ts
+++ b/src/tests/cli.spec.ts
@@ -1,0 +1,63 @@
+import path from "path";
+import { main } from "../cli";
+
+const MISSING_TAPES_DIR = path.join(__dirname, "tapes", "does-not-exist");
+
+describe("CLI — --omit-empty-tapes with missing tapes directory", () => {
+  test("logs an informational message and starts without panicking", async () => {
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const server = await main([
+        "node",
+        "proxay",
+        "--mode",
+        "replay",
+        "--tapes-dir",
+        MISSING_TAPES_DIR,
+        "--port",
+        "3097",
+        "--omit-empty-tapes",
+      ]);
+      await server!.stop();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "treating all tapes as empty (--omit-empty-tapes)",
+        ),
+      );
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+
+  test("panics without the flag", async () => {
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(
+        main([
+          "node",
+          "proxay",
+          "--mode",
+          "replay",
+          "--tapes-dir",
+          MISSING_TAPES_DIR,
+          "--port",
+          "3098",
+        ]),
+      ).rejects.toThrow("process.exit called");
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/src/tests/cli.spec.ts
+++ b/src/tests/cli.spec.ts
@@ -8,7 +8,7 @@ describe("CLI — --omit-empty-tapes with missing tapes directory", () => {
     const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");
     });
-    const infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    const infoSpy = jest.spyOn(console, "info").mockImplementation(jest.fn());
     try {
       const server = await main([
         "node",
@@ -39,7 +39,7 @@ describe("CLI — --omit-empty-tapes with missing tapes directory", () => {
     const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit called");
     });
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(jest.fn());
     try {
       await expect(
         main([

--- a/src/tests/omit-empty-tapes.spec.ts
+++ b/src/tests/omit-empty-tapes.spec.ts
@@ -1,0 +1,103 @@
+import axios from "axios";
+import { existsSync } from "fs";
+import { join } from "path";
+import { PROXAY_HOST } from "./config";
+import { setupServers } from "./setup";
+import { SIMPLE_TEXT_PATH, SIMPLE_TEXT_RESPONSE } from "./testserver";
+
+describe("omitEmptyTapes — record mode", () => {
+  const servers = setupServers({ mode: "record", omitEmptyTapes: true });
+
+  test("does not create a tape file when no requests are made", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "empty-tape" });
+    expect(existsSync(join(servers.tapeDir, "empty-tape.yml"))).toBe(false);
+  });
+
+  test("creates a tape file once a request is made", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "non-empty-tape" });
+    await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
+    expect(existsSync(join(servers.tapeDir, "non-empty-tape.yml"))).toBe(true);
+  });
+});
+
+describe("omitEmptyTapes — record mode (default behaviour preserved)", () => {
+  const servers = setupServers({ mode: "record" });
+
+  test("creates an empty tape file when no requests are made", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "empty-tape" });
+    expect(existsSync(join(servers.tapeDir, "empty-tape.yml"))).toBe(true);
+  });
+});
+
+describe("omitEmptyTapes — mimic mode", () => {
+  const servers = setupServers({ mode: "mimic", omitEmptyTapes: true });
+
+  test("does not create a tape file when no requests are made", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "empty-mimic-tape" });
+    expect(existsSync(join(servers.tapeDir, "empty-mimic-tape.yml"))).toBe(false);
+  });
+});
+
+describe("omitEmptyTapes — replay mode", () => {
+  setupServers({ mode: "replay", omitEmptyTapes: true });
+
+  test("switching to a non-existent tape succeeds (returns 200)", async () => {
+    const response = await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "does-not-exist-tape",
+    });
+    expect(response.status).toBe(200);
+  });
+
+  test("logs an informational message instead of a warning when tape is missing", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+        tape: "does-not-exist-tape",
+      });
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("treating as empty (--omit-empty-tapes)"),
+      );
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("No tape found with name"),
+      );
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("requests against an empty (missing) tape return no response (500)", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "does-not-exist-tape",
+    });
+    await expect(
+      axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`),
+    ).rejects.toEqual(new Error("Request failed with status code 500"));
+  });
+});
+
+describe("omitEmptyTapes — replay mode (default behaviour preserved)", () => {
+  setupServers({ mode: "replay" });
+
+  test("switching to a non-existent tape still returns 404 without the flag", async () => {
+    await expect(
+      axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+        tape: "does-not-exist-tape",
+      }),
+    ).rejects.toEqual(new Error("Request failed with status code 404"));
+  });
+});
+
+describe("omitEmptyTapes — replay mode with existing tape", () => {
+  setupServers({
+    mode: "replay",
+    tapeDirName: "replay",
+    omitEmptyTapes: true,
+  });
+
+  test("still replays from an existing tape correctly", async () => {
+    const response = await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
+    expect(response.data).toBe(SIMPLE_TEXT_RESPONSE);
+  });
+});

--- a/src/tests/omit-empty-tapes.spec.ts
+++ b/src/tests/omit-empty-tapes.spec.ts
@@ -7,7 +7,11 @@ import { setupServers } from "./setup";
 import { SIMPLE_TEXT_PATH, SIMPLE_TEXT_RESPONSE } from "./testserver";
 
 describe("omitEmptyTapes — record mode", () => {
-  const servers = setupServers({ mode: "record", omitEmptyTapes: true });
+  const servers = setupServers({
+    mode: "record",
+    tapeDirName: "omit-record",
+    omitEmptyTapes: true,
+  });
 
   test("does not create a tape file when no requests are made", async () => {
     await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "empty-tape" });
@@ -24,7 +28,10 @@ describe("omitEmptyTapes — record mode", () => {
 });
 
 describe("omitEmptyTapes — record mode (default behaviour preserved)", () => {
-  const servers = setupServers({ mode: "record" });
+  const servers = setupServers({
+    mode: "record",
+    tapeDirName: "omit-record-default",
+  });
 
   test("creates an empty tape file when no requests are made", async () => {
     await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "empty-tape" });
@@ -118,7 +125,11 @@ describe("omitEmptyTapes — replay mode with existing tape", () => {
 });
 
 describe("omitEmptyTapes — stale tape handling on re-record", () => {
-  const servers = setupServers({ mode: "record", omitEmptyTapes: true });
+  const servers = setupServers({
+    mode: "record",
+    tapeDirName: "omit-stale",
+    omitEmptyTapes: true,
+  });
 
   test("deletes a pre-existing tape file when re-recording with no requests", async () => {
     // Pre-seed a stale tape file

--- a/src/tests/omit-empty-tapes.spec.ts
+++ b/src/tests/omit-empty-tapes.spec.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
-import { existsSync } from "fs";
+import { existsSync, writeFileSync } from "fs";
+import { ensureDirSync } from "fs-extra";
 import { join } from "path";
 import { PROXAY_HOST } from "./config";
 import { setupServers } from "./setup";
@@ -41,6 +42,14 @@ describe("omitEmptyTapes — mimic mode", () => {
     expect(existsSync(join(servers.tapeDir, "empty-mimic-tape.yml"))).toBe(
       false,
     );
+  });
+
+  test("creates a tape file once a request is made against a missing tape", async () => {
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "mimic-new-tape",
+    });
+    await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
+    expect(existsSync(join(servers.tapeDir, "mimic-new-tape.yml"))).toBe(true);
   });
 });
 
@@ -105,5 +114,44 @@ describe("omitEmptyTapes — replay mode with existing tape", () => {
   test("still replays from an existing tape correctly", async () => {
     const response = await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
     expect(response.data).toBe(SIMPLE_TEXT_RESPONSE);
+  });
+});
+
+describe("omitEmptyTapes — stale tape handling on re-record", () => {
+  const servers = setupServers({ mode: "record", omitEmptyTapes: true });
+
+  test("deletes a pre-existing tape file when re-recording with no requests", async () => {
+    // Pre-seed a stale tape file
+    ensureDirSync(servers.tapeDir);
+    writeFileSync(
+      join(servers.tapeDir, "stale-tape.yml"),
+      "http_interactions: []",
+      "utf8",
+    );
+
+    // Switch to that tape without making any requests
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "stale-tape" });
+
+    // Stale file should be gone
+    expect(existsSync(join(servers.tapeDir, "stale-tape.yml"))).toBe(false);
+  });
+
+  test("overwrites a pre-existing tape file when re-recording with requests", async () => {
+    // Pre-seed a stale tape with some content
+    ensureDirSync(servers.tapeDir);
+    writeFileSync(
+      join(servers.tapeDir, "overwrite-tape.yml"),
+      "http_interactions: []",
+      "utf8",
+    );
+
+    // Switch to that tape and make a request
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "overwrite-tape",
+    });
+    await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
+
+    // File should exist and contain the new interaction
+    expect(existsSync(join(servers.tapeDir, "overwrite-tape.yml"))).toBe(true);
   });
 });

--- a/src/tests/omit-empty-tapes.spec.ts
+++ b/src/tests/omit-empty-tapes.spec.ts
@@ -14,7 +14,9 @@ describe("omitEmptyTapes — record mode", () => {
   });
 
   test("creates a tape file once a request is made", async () => {
-    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "non-empty-tape" });
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "non-empty-tape",
+    });
     await axios.get(`${PROXAY_HOST}${SIMPLE_TEXT_PATH}`);
     expect(existsSync(join(servers.tapeDir, "non-empty-tape.yml"))).toBe(true);
   });
@@ -33,8 +35,12 @@ describe("omitEmptyTapes — mimic mode", () => {
   const servers = setupServers({ mode: "mimic", omitEmptyTapes: true });
 
   test("does not create a tape file when no requests are made", async () => {
-    await axios.post(`${PROXAY_HOST}/__proxay/tape`, { tape: "empty-mimic-tape" });
-    expect(existsSync(join(servers.tapeDir, "empty-mimic-tape.yml"))).toBe(false);
+    await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
+      tape: "empty-mimic-tape",
+    });
+    expect(existsSync(join(servers.tapeDir, "empty-mimic-tape.yml"))).toBe(
+      false,
+    );
   });
 });
 
@@ -49,8 +55,8 @@ describe("omitEmptyTapes — replay mode", () => {
   });
 
   test("logs an informational message instead of a warning when tape is missing", async () => {
-    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, "log").mockImplementation(jest.fn());
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(jest.fn());
     try {
       await axios.post(`${PROXAY_HOST}/__proxay/tape`, {
         tape: "does-not-exist-tape",

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -11,12 +11,14 @@ export function setupServers({
   defaultTapeName = "default",
   exactRequestMatching,
   sendProxyPort = false,
+  omitEmptyTapes,
 }: {
   mode: Mode;
   tapeDirName?: string;
   defaultTapeName?: string;
   exactRequestMatching?: boolean;
   sendProxyPort?: boolean;
+  omitEmptyTapes?: boolean;
 }) {
   const tapeDir = path.join(__dirname, "tapes", tapeDirName);
   const servers = { tapeDir } as {
@@ -42,6 +44,7 @@ export function setupServers({
       enableLogging: true,
       exactRequestMatching,
       proxyPortToSend: sendProxyPort ? PROXAY_PORT : undefined,
+      omitEmptyTapes,
     });
     await Promise.all([
       servers.proxy.start(PROXAY_PORT),

--- a/src/tests/tapes/.gitignore
+++ b/src/tests/tapes/.gitignore
@@ -1,3 +1,6 @@
 /mimic/
 /record/
 /switching-tapes/
+/omit-record/
+/omit-record-default/
+/omit-stale/


### PR DESCRIPTION
## Summary

- Adds `--omit-empty-tapes` flag to avoid writing tape files that contain no recorded interactions
- In replay mode, a missing tape is treated as empty (returns no match) rather than a 404 error
- Fixes a CLI-level panic when the tapes directory doesn't exist in replay mode with the flag set

## Motivation

When running multiple Proxay instances in parallel (e.g. one per backend service in `bff-client`), every instance creates a tape file on startup even if it receives zero traffic for a given test. This results in hundreds of `http_interactions: []` files cluttering the repo. This flag eliminates them.

## Changes

- `src/server.ts` — skip empty-file write on tape load in `record`/`mimic` modes; treat missing file as empty in `replay` mode with an informational log
- `src/cli.ts` — add `--omit-empty-tapes` option; log instead of panic when tapes dir is missing in replay mode with the flag; export `main` and use a fresh `Command` instance per call (enables in-process CLI testing)
- `src/tests/setup.ts` — forward `omitEmptyTapes` option through `setupServers()`
- `src/tests/omit-empty-tapes.spec.ts` — 9 integration tests covering all modes and default behaviour preservation
- `src/tests/cli.spec.ts` — 2 CLI-level tests covering the missing-dir log and panic paths
- `README.md` — document the new flag

## Test plan

- [ ] All existing tests remain green
- [ ] `omit-empty-tapes.spec.ts` — 9 tests covering record, mimic, replay modes
- [ ] `cli.spec.ts` — 2 tests covering CLI validation paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
